### PR TITLE
add kernel version info in found first bad commit log, it will more readable

### DIFF
--- a/kab-lib.sh
+++ b/kab-lib.sh
@@ -305,8 +305,11 @@ function do_test() {
 }
 
 function success_report() {
+        res=$(git bisect log | grep "first bad commit" | tail -n 1)
+        #send the kernel version to log
+        LOG Found the version:  $res
 	# sending email
-	echo $success_string | esmtp $REPORT_EMAIL
+	echo $res | esmtp $REPORT_EMAIL
 
 }
 


### PR DESCRIPTION
after change,the log result will like below:
cat /boot/.kdump-auto-bisect.log
......
Feb18:22:08:02 - 6b23f9140d8d37b5b74b0e8dc02094c3297edf77 is the first bad commit
Feb18:22:08:02 - stoping
Feb18:22:08:02 - Found the version: # first bad commit: [6b23f9140d8d37b5b74b0e8dc02094c3297edf77] 4.18.0-424.el8.x86_64
Feb18:22:08:02 - report sent
Feb18:22:08:02 - kab service disabled
Feb18:22:08:02 - stoped
